### PR TITLE
Fix key,value declaration for custom parsers in parsers.conf.j2 template

### DIFF
--- a/templates/parsers.conf.j2
+++ b/templates/parsers.conf.j2
@@ -121,6 +121,8 @@
 # custom parser
 {% for parser in fluentbit_custom_parsers %}
 [PARSER]
-    {{ key }} {{ parser[key] }}
+{% for key,value in parser.items() %}
+    {{ key }} {{ value }}
+{% endfor %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
https://github.com/be99inner/ansible-fluentbit/blob/7de7fb7d419e1cd74ca0c56c0e7774dfbeaf70d8/templates/parsers.conf.j2#L120-L126

The reference lines doesn't work when using Ansible 2.9 (not sure about other version) and return this error
```
TASK [be99inner.fluentbit : Configure fluentbit via configure template] ******************************************************************************************
failed: [test] (item=parsers.conf) => {"ansible_loop_var": "item", "changed": false, "item": "parsers.conf", "msg": "AnsibleUndefinedVariable: 'key' is undefined"}
```

Replacing above lines with this snippet make it works
```
{% if fluentbit_custom_parsers != [] %}
# custom parser
{% for parser in fluentbit_custom_parsers %}
[PARSER]
{% for key,value in parser.items() %}
    {{ key }} {{ value }}
{% endfor %}
{% endfor %}
{% endif %}
```